### PR TITLE
Add Planet for the MySQL Community.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Computers & Programming
 
 - [OpenStreetMap Blogs](https://blogs.openstreetmap.org) - [(Config)](https://github.com/gravitystorm/blogs.osm.org)
 - [Unvanquished Activity](https://unvanquished.net/activity/) - [(Config)](https://github.com/Unvanquished/pluto-devfeeds)
+- [Planet for the MySQL Community](http://planet-beta-pluto.oursqlcommunity.org/) (currently in Beta) - [(Config)](https://github.com/oursqlcommunity-org/planet)
 
 Upcoming
 


### PR DESCRIPTION
I suggest adding "Planet for the MySQL Community" to the inventory of website running Planet Pluto.  The website is currently in beta and will probably stay in beta for a few weeks/months.  A blog post announcing this can be found in (1).

(1): https://jfg-mysql.blogspot.com/2020/05/planet-for-the-mysql-community-pluto-beta.html